### PR TITLE
fix: explicitly assign apisix host

### DIFF
--- a/deployment/kubernetes/flood-api.yaml
+++ b/deployment/kubernetes/flood-api.yaml
@@ -86,8 +86,13 @@ spec:
   http:
     - name: flood-frontend
       match:
+        paths:
+          - /*
         hosts:
-          - flood*.openepi.io
+          - flood-dev1.openepi.io
+          - flood-dev2.openepi.io
+          - flood-test.openepi.io
+          - flood.openepi.io
       backends:
         - serviceName: flood-frontend
           servicePort: 80
@@ -114,7 +119,7 @@ spec:
     username: postgres
     autoGeneratePassword: true
     passwordSecretRef:
-      name: db-password
+      name: flood-frontend-db-password
       namespace: apps
       key: password
     finalSnapshotIdentifier: flood-frontend-db-final-snapshot


### PR DESCRIPTION
Fix some bugs in the ApisixRoute

- paths is a required parameter
- hosts can not contain wildcards. Currently just hardcoded the currently used environments. Would be better to set this automatically based on the environment, but this seems non-trivial
- renamed the k8s-secret called "db-password" -> "flood-frontend-db-password" to avoid confusion in the future