### PR TITLE
fix: make sure to logout completely

### DIFF
--- a/frontend/lib/auth-utils.ts
+++ b/frontend/lib/auth-utils.ts
@@ -1,6 +1,6 @@
 import KeycloakProvider from 'next-auth/providers/keycloak';
 import { getServerSession, type NextAuthOptions } from 'next-auth';
-import type { DefaultSession, Session } from 'next-auth';
+import type { DefaultSession } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
@@ -8,18 +8,54 @@ declare module 'next-auth' {
   }
 }
 
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id_token: string;
+  }
+}
+
+const keycloakProvider = KeycloakProvider({
+  clientId: process.env.KEYCLOAK_ID!,
+  clientSecret: process.env.KEYCLOAK_SECRET!,
+  issuer: process.env.KEYCLOAK_ISSUER,
+});
+
 export const authOptions: NextAuthOptions = {
-  providers: [
-    KeycloakProvider({
-      clientId: process.env.KEYCLOAK_ID ?? '',
-      clientSecret: process.env.KEYCLOAK_SECRET ?? '',
-      issuer: process.env.KEYCLOAK_ISSUER,
-    }),
-  ],
+  providers: [keycloakProvider],
   callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        if (account.id_token) {
+          token.id_token = account.id_token;
+        } else {
+          console.error('No id_token in account', account);
+        }
+      }
+      return token;
+    },
     async session({ session, token }) {
       if (session.user) session.user.id = token.sub;
       return session;
+    },
+  },
+  events: {
+    // this performs the final sign out handshake for the keycloak provider,
+    // see https://stackoverflow.com/questions/71872587/logout-from-next-auth-with-keycloak-provider-not-works
+    async signOut({ token }) {
+      const { id_token } = token;
+      try {
+        const params = new URLSearchParams({ id_token_hint: id_token });
+        const response = await fetch(
+          `${keycloakProvider.options?.issuer}/protocol/openid-connect/logout?${params.toString()}`
+        );
+        console.log(
+          'Completed post-logout handshake',
+          response.status,
+          response.statusText
+        );
+      } catch (e: any) {
+        console.error('Unable to perform post-logout handshake', e);
+      }
     },
   },
 };


### PR DESCRIPTION
Previously the logout-button only logged the user out for next-auth, not Keycloak. When logging in and logging out the user therefore could not choose to log in with a different account. The user also did not have to type in any credentials. To fix this, an event handler was added to the next-auth signOut-event that sends a logout-request to the keycloak-instance