### PR TITLE
fix: do not use special characters for keycloak

### DIFF
--- a/infrastructure/keycloak.ts
+++ b/infrastructure/keycloak.ts
@@ -85,7 +85,10 @@ export default class KeycloakService extends pulumi.ComponentResource {
 
     const keycloakAdminPassword = new random.RandomPassword(
       'keycloak-admin-password',
-      { length: 128 },
+      {
+        length: 128,
+        special: false,
+      },
       childOptions
     );
 
@@ -156,7 +159,10 @@ export default class KeycloakService extends pulumi.ComponentResource {
 
     const keycloakClientSecret = new random.RandomPassword(
       'keycloak-client-secret',
-      { length: 128 },
+      {
+        length: 128,
+        special: false,
+      },
       childOptions
     );
 


### PR DESCRIPTION
keycloak crashes for some special characters, and will therefore crash completely unpredictably depending on the secret created. Fixed this by disallowing special characters